### PR TITLE
Fix missing key error and missing alt tag on About page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -1,36 +1,40 @@
 import Layout from "../components/layout";
 
-function About() {
+function AboutPage() {
   return (
     <Layout>
-      <div className="flex flex-col md:flex-row">
-        <div className="md:w-1/2">
+      <div className="flex flex-col space-y-6 md:flex-row md:space-x-6 md:space-y-0">
+        <div className="space-y-6 md:w-1/2">
           {[
             {
               heading: `What is Tailwind?`,
               body: `Tailwind CSS is a highly customizable, low-level CSS framework that gives you all
               of the building blocks you need to build bespoke designs without any
-              annoying opinionated styles you have to fight to override.`
+              annoying opinionated styles you have to fight to override.`,
             },
             {
               heading: `What is Next.js?`,
               body: `Next.js is a minimalistic framework for creating server-rendered
-              React applications.`
-            }
-          ].map(section => (
-            <>
-              <h2 className="font-bold mb-3 text-xl">{section.heading}</h2>
-              <p className="mb-6">{section.body}</p>
-            </>
+              React applications.`,
+            },
+          ].map((section) => (
+            <div key={section.heading}>
+              <h2 className="mb-3 text-xl font-bold">{section.heading}</h2>
+              <p>{section.body}</p>
+            </div>
           ))}
         </div>
 
-        <div className="md:ml-6 md:w-1/2">
-          <img src="critter.svg" className="w-full" />
+        <div className="md:w-1/2">
+          <img
+            alt="A one-eyed alien holding a broken cable connected between a server and a desktop computer"
+            className="w-full"
+            src="critter.svg"
+          />
         </div>
       </div>
     </Layout>
   );
 }
 
-export default About;
+export default AboutPage;


### PR DESCRIPTION
This PR:
- Fixes a missing key error on the About page
- Renames the component to `AboutPage`
- Makes use of Tailwind's new `space-*` utilities
- Adds an alt tag to the illustration