### PR TITLE
Add rustywind npm script to sort Tailwind CSS classes

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -1,7 +1,7 @@
 function Footer() {
   return (
     <footer className="bg-blue-500">
-      <ul className="flex items-center justify-between max-w-4xl mx-auto p-4 md:p-8 text-sm text-white">
+      <ul className="flex items-center justify-between max-w-4xl p-4 mx-auto text-sm text-white md:p-8">
         <li>
           Created by{" "}
           <a href="https://bryant.io" target="_blank" className="font-bold">

--- a/components/header.js
+++ b/components/header.js
@@ -6,26 +6,26 @@ function Header() {
 
   return (
     <header className="bg-teal-500">
-      <div className="flex flex-wrap md:flex-no-wrap items-center justify-between max-w-4xl mx-auto p-4 md:p-8">
+      <div className="flex flex-wrap items-center justify-between max-w-4xl p-4 mx-auto md:flex-no-wrap md:p-8">
         <div className="flex items-center">
           <img
             src="tailwind-logo.svg"
-            className="mr-3 text-white w-10"
+            className="w-10 mr-3 text-white"
           />
 
           <Link href="/">
-            <a className="font-bold text-white text-xl">
+            <a className="text-xl font-bold text-white">
               Next.js Starter Tailwind
             </a>
           </Link>
         </div>
 
         <button
-          className="block md:hidden border border-white flex items-center px-3 py-2 rounded text-white"
+          className="flex items-center block px-3 py-2 text-white border border-white rounded md:hidden"
           onClick={() => toggleExpansion(!isExpanded)}
         >
           <svg
-            className="fill-current h-3 w-3"
+            className="w-3 h-3 fill-current"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-starter-tailwind",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6137,6 +6137,12 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rustywind": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/rustywind/-/rustywind-0.6.6.tgz",
+      "integrity": "sha512-BpwK6+eigWoIHF6dHOW1DdgD5urFueEsr8GBwcXeQNIc4oVoYDQdbSeieEp9qmdqHWAOJgiAg011VnbRHsXWGw==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Next.js starter styled with Tailwind CSS",
   "main": "index.js",
   "scripts": {
+    "analyze:tailwind-css-class-order": "rustywind --dry-run .",
+    "analyze": "npm run analyze:tailwind-css-class-order",
+    "fix:tailwind-css-class-order": "rustywind --write .",
+    "fix": "npm run fix:tailwind-css-class-order",
     "dev": "next",
     "build": "next build",
     "export": "npm run build && next export",
@@ -27,6 +31,7 @@
   },
   "devDependencies": {
     "autoprefixer": "9.8.6",
+    "rustywind": "0.6.6",
     "tailwindcss": "1.6.2"
   }
 }


### PR DESCRIPTION
This PR:

* Pulls in [rustywind](https://github.com/avencera/rustywind) as a dependency
* Adds 4 new npm scripts:
  * `analyze:tailwind-css-class-order` - Outputs a list of files with Tailwind CSS classes that can be sorted by rustywind
  * `analyze` - For now, this just runs `analyze:tailwind-css-class-order`. In the future, it will also do a dry run of Prettier and ESLint.
  * `fix:tailwind-css-class-order` - Sorts Tailwind CSS classes in any files it can find.
  * `fix` - For now, this just runs `fix:tailwind-css-class-order`. In the future, it will also run Prettier and ESLint.

Special thanks to @Mozart409 who originally did this work in https://github.com/taylorbryant/next-starter-tailwind/pull/90!